### PR TITLE
Add Google Tag Manager and Replace GA Tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,13 @@
 <html lang="en">
     <head>
         
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-8E9QYJ469R"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', 'G-8E9QYJ469R');
-        </script>
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-NMHZDF7');</script>
+        <!-- End Google Tag Manager -->
         
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -690,5 +688,9 @@
 
         <!-- Scripts -->
         <script src="./assets/js/script.js"></script>
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NMHZDF7"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
     </body>
 </html>


### PR DESCRIPTION
After more research, it appears we cannot get as granular as we need to track specific events just by using GA. We need to configure GTM to set up specific events that are then tracked using GA. To do this, we need to use GTM triggers.