### PR TITLE
Add `data-testid` to waitlist button and links

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="btn"
-                                    data-testid="join-waitlist-button">Join Waitlist</a>
+                                    data-testid="join-waitlist-button" Join Waitlist</a>
                                 >
                             </li>
                         </ul>
@@ -153,7 +153,7 @@
                                 target="_blank"
                                 rel="noreferrer noopener"
                                 class="btn"
-                                data-testid="join-waitlist-button">Join Waitlist</a>
+                                data-testid="join-waitlist-button" Join Waitlist</a>
                             >
                         </div>
                         <div class="hero-img">
@@ -194,7 +194,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link">Join Waitlist</a>
+                                    data-testid="join-waitlist-link" Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-img">
@@ -228,7 +228,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link">Join Waitlist</a>
+                                    data-testid="join-waitlist-link" Join Waitlist</a>
                                 >
                             </div>
                         </div>
@@ -289,7 +289,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link">Join Waitlist</a>
+                                    data-testid="join-waitlist-link" Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-img">
@@ -324,7 +324,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link">Join Waitlist</a>
+                                    data-testid="join-waitlist-link" Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-image-flex">

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="btn"
-                                    >Join Waitlist</a
+                                    data-testid="join-waitlist-button">Join Waitlist</a>
                                 >
                             </li>
                         </ul>
@@ -153,7 +153,7 @@
                                 target="_blank"
                                 rel="noreferrer noopener"
                                 class="btn"
-                                >Join Waitlist</a
+                                data-testid="join-waitlist-button">Join Waitlist</a>
                             >
                         </div>
                         <div class="hero-img">
@@ -194,7 +194,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    >Join Waitlist</a
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-img">
@@ -228,7 +228,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    >Join Waitlist</a
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                         </div>
@@ -289,7 +289,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    >Join Waitlist</a
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-img">
@@ -324,7 +324,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    >Join Waitlist</a
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-image-flex">

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="btn"
-                                    data-testid="join-waitlist-button" Join Waitlist</a>
+                                    data-testid="join-waitlist-button">Join Waitlist</a>
                                 >
                             </li>
                         </ul>
@@ -153,7 +153,7 @@
                                 target="_blank"
                                 rel="noreferrer noopener"
                                 class="btn"
-                                data-testid="join-waitlist-button" Join Waitlist</a>
+                                data-testid="join-waitlist-button">Join Waitlist</a>
                             >
                         </div>
                         <div class="hero-img">
@@ -194,7 +194,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link" Join Waitlist</a>
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-img">
@@ -228,7 +228,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link" Join Waitlist</a>
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                         </div>
@@ -324,7 +324,7 @@
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     class="link"
-                                    data-testid="join-waitlist-link" Join Waitlist</a>
+                                    data-testid="join-waitlist-link">Join Waitlist</a>
                                 >
                             </div>
                             <div class="service-image-flex">


### PR DESCRIPTION
In order to configure GTM and GA properly and with stability, we need to give our critical components more definitive attributes to accurately trigger GTM. I have attempted to give the `join waitlist` buttons a testID. I've also given the `join waitlist` links a slightly different testID naming convention. That will allow us to set up different triggers based on if buttons or links are clicked to access the waitlist form.
